### PR TITLE
add escape for lyrics API

### DIFF
--- a/lib/rdio.rb
+++ b/lib/rdio.rb
@@ -40,7 +40,7 @@ module Rdio
 
   def self.lyrics_for(artist, title)
     uri = URI('http://makeitpersonal.co/lyrics')
-    params = { :artist => artist, :title => title }
+    params = { :artist => artist.gsub(/[<>]/, ' '), :title => title.gsub(/[<>]/, ' ') }
     uri.query = URI.encode_www_form(params)
 
     res = Net::HTTP.get_response(uri)


### PR DESCRIPTION
http://makeitpersonal.co/lyrics API returns weird results when `artist` or `title` parameter has '<' or '>' char.  This happens when a user tries to fetch lyrics for songs like ["With>You"](http://www.rdio.com/artist/Linkin_Park/album/Reanimation/track/Wth%3EYou/).

This pull request will replace '<' and '>' to single space when a user runs command like `rdio lyrics`.
