### PR TITLE
RFC: Add basic console as proof of concept

### DIFF
--- a/bin/rdio
+++ b/bin/rdio
@@ -18,8 +18,10 @@ if ARGV[0] == 'c' || ARGV[0] == 'console'
     if input == 'exit'
       exit
     else
-      args = input.split(' ')
-      Rdio.run(args)
+      puts Benchmark.measure {
+        args = input.split(' ')
+        Rdio.run(args)
+      }
     end
   end
 else


### PR DESCRIPTION
If you're using the cli frequently, you have to deal with the boot up time of the interpreter, loading of libraries etc that adds a good 1.5s to each command, at least on my machine. So I thought it might be useful to have a console command that will just allow us to maintain a rdio-cli session open and skip that boot time.

For example, without console:

```
$ time rdio help
-- output --
rdio help  1.45s user 0.13s system 99% cpu 1.581 total

$ time rdio current
-- output --
rdio current  1.75s user 0.22s system 85% cpu 2.290 total
```

With console:

```
$ rdio c
> help
-- output --
0.010000   0.010000   0.020000 (  0.015161)
> current
-- output --
0.000000   0.010000   0.420000 (  0.766850)
```

Benchmarking code left in so you can give it a try yourself.
